### PR TITLE
Fixed BBP 8-bit in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ $$
 ## Bailey–Borwein–Plouffe Algorithm(8bit)
 
 $$
-π=\frac{1}{64}\underset{n=0}{\overset{\infty }\frac{1}{256^n} \left(\frac{256}{16 n+1}-\frac{128}{16 n+4}-\frac{64}{16 n+5}-\frac{64}{16 n+6}+\frac{16}{16 n+9}-\frac{8}{16 n+12}-\frac{4}{16 n+13}-\frac{4}{16 n+14}\right)
+π=\frac{1}{64}\underset{n=0}{\overset{\infty }{\sum}}\frac{1}{256^n} \left(\frac{256}{16 n+1}-\frac{128}{16 n+4}-\frac{64}{16 n+5}-\frac{64}{16 n+6}+\frac{16}{16 n+9}-\frac{8}{16 n+12}-\frac{4}{16 n+13}-\frac{4}{16 n+14}\right)
 $$
 
 ## Bailey–Borwein–Plouffe Algorithm(16bit)


### PR DESCRIPTION
There was a `\sum` missing